### PR TITLE
SSL related fields are not initialised, resulting in an error

### DIFF
--- a/ibmmq/mqiMQCD.go
+++ b/ibmmq/mqiMQCD.go
@@ -161,6 +161,8 @@ func copyCDtoC(mqcd *C.MQCD, gocd *MQCD) {
 	C.memset((unsafe.Pointer)(&mqcd.MCASecurityId[0]), 0, C.MQ_SECURITY_ID_LENGTH)
 	C.memset((unsafe.Pointer)(&mqcd.RemoteSecurityId[0]), 0, C.MQ_SECURITY_ID_LENGTH)
 	setMQIString((*C.char)(&mqcd.SSLCipherSpec[0]), gocd.SSLCipherSpec, C.MQ_SSL_CIPHER_SPEC_LENGTH)
+	mqcd.SSLPeerNamePtr = C.MQPTR(nil)
+	mqcd.SSLPeerNameLength = 0
 	if gocd.SSLPeerName != "" {
 		mqcd.SSLPeerNamePtr = C.MQPTR(unsafe.Pointer(C.CString(gocd.SSLPeerName)))
 		mqcd.SSLPeerNameLength = C.MQLONG(len(gocd.SSLPeerName))


### PR DESCRIPTION
Hi,

When connecting to a queue manager using Connx and a MQCNO/MQCD, 
a "pointer being freed was not allocated" error is generated at:
https://github.com/ibm-messaging/mq-golang/blob/master/ibmmq/mqiMQCD.go#L206

After investigation, it appears that the SSL related fields are not initialised in the C struct:
https://github.com/ibm-messaging/mq-golang/blob/master/ibmmq/mqiMQCD.go#L97
