### PR TITLE
check rc incase it is not no_more_msg

### DIFF
--- a/mqmetric/discover.go
+++ b/mqmetric/discover.go
@@ -472,7 +472,7 @@ cases where multiple pieces of data have to be collated for the same
 gauge. Conversely, there may be times when this is called but there
 are no metrics to update.
 */
-func ProcessPublications() {
+func ProcessPublications() error {
 	var err error
 	var data []byte
 
@@ -568,8 +568,16 @@ func ProcessPublications() {
 					elem.Values[objectName] = value
 				}
 			}
+		} else {
+			// err != nil
+			mqreturn := err.(*ibmmq.MQReturn)
+
+			if mqreturn.MQCC == ibmmq.MQCC_FAILED && mqreturn.MQRC != ibmmq.MQRC_NO_MSG_AVAILABLE {
+				return mqreturn
+			}
 		}
 	}
+	return nil
 }
 
 /*

--- a/mqmetric/mqif.go
+++ b/mqmetric/mqif.go
@@ -180,7 +180,6 @@ func getMessage(wait bool) ([]byte, error) {
 func getMessageWithHObj(wait bool, hObj ibmmq.MQObject) ([]byte, error) {
 	var err error
 	var datalen int
-	var mqreturn *ibmmq.MQReturn
 
 	getmqmd := ibmmq.NewMQMD()
 	gmo := ibmmq.NewMQGMO()
@@ -196,18 +195,6 @@ func getMessageWithHObj(wait bool, hObj ibmmq.MQObject) ([]byte, error) {
 	}
 
 	datalen, err = replyQObj.Get(getmqmd, gmo, getBuffer)
-	if err != nil {
-		mqreturn = err.(*ibmmq.MQReturn)
-
-		if mqreturn.MQRC == ibmmq.MQRC_Q_MGR_NOT_AVAILABLE ||
-			mqreturn.MQRC == ibmmq.MQRC_Q_MGR_NAME_ERROR ||
-			mqreturn.MQRC == ibmmq.MQRC_Q_MGR_QUIESCING {
-			return nil, fmt.Errorf("Queue Manager error: %v", err)
-		}
-		if mqreturn.MQCC == ibmmq.MQCC_FAILED && mqreturn.MQRC != ibmmq.MQRC_NO_MSG_AVAILABLE {
-			return nil, fmt.Errorf("Get message error: %v", err)
-		}
-	}
 
 	return getBuffer[0:datalen], err
 }


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [x] You have completed the PR template below:

## What

* Modified return from `getMessageWithHObj` to return the mqreturn error for later processing.
* Modified `ProcessPublications()` to verify error returned from `getMessage()` was `MQRC_NO_MSG_AVAILABLE` and if not return the error to the caller.

## How

Added so that the metrics publication code would be able to detect other errors such as `MQRC_Q_MGR_QUIESCING` and so disconnect and stop the program from preventing the queue manager stopping.

## Testing

Mnaual

## Issues

Fixes #48 
