### PR TITLE
Allow compiling against v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This repository demonstrates how you can call IBM MQ from applications written i
 
 This repository previously contained sample programs that exported MQ statistics to some monitoring packages. These have now been moved to a new [GitHub repository called mq-metric-samples](https://github.com/ibm-messaging/mq-metric-samples).
 
-A minimum level of MQ V9 is required to build these packages.
+A minimum level of MQ V9 is required to build these packages (with `-tags MQv8`, v8 may be enough).
 The monitoring data published by the queue manager is not available before that version; the interface also assumes availability of MQI structures from that level of MQ.
+
 
 ## Health Warning
 

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -79,6 +79,9 @@ func NewMQCSP() *MQCSP {
 	return csp
 }
 
+var copyCCDTUrlToC func(mqcno *C.MQCNO, gocno *MQCNO)
+var copyCCDTUrlFromC func(gocno *MQCNO, mqcno *C.MQCNO)
+
 func copyCNOtoC(mqcno *C.MQCNO, gocno *MQCNO) {
 	var i int
 	var mqcsp C.PMQCSP
@@ -151,13 +154,8 @@ func copyCNOtoC(mqcno *C.MQCNO, gocno *MQCNO) {
 		mqcno.SecurityParmsPtr = nil
 	}
 
-	mqcno.CCDTUrlOffset = 0
-	if len(gocno.CCDTUrl) != 0 {
-		mqcno.CCDTUrlPtr = C.PMQCHAR(unsafe.Pointer(C.CString(gocno.CCDTUrl)))
-		mqcno.CCDTUrlLength = C.MQLONG(len(gocno.CCDTUrl))
-	} else {
-		mqcno.CCDTUrlPtr = nil
-		mqcno.CCDTUrlLength = 0
+	if copyCCDTUrlToC != nil {
+		copyCCDTUrlToC(mqcno, gocno)
 	}
 	return
 }
@@ -186,8 +184,8 @@ func copyCNOfromC(mqcno *C.MQCNO, gocno *MQCNO) {
 		C.free(unsafe.Pointer(mqcno.SSLConfigPtr))
 	}
 
-	if mqcno.CCDTUrlPtr != nil {
-		C.free(unsafe.Pointer(mqcno.CCDTUrlPtr))
+	if copyCCDTUrlFromC != nil {
+		copyCCDTUrlFromC(gocno, mqcno)
 	}
 	return
 }

--- a/ibmmq/mqiMQCNO_v9.go
+++ b/ibmmq/mqiMQCNO_v9.go
@@ -1,0 +1,51 @@
+// +build !MQv8
+
+package ibmmq
+
+/*
+  Copyright (c) IBM Corporation 2016
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific
+
+   Contributors:
+     Mark Taylor - Initial Contribution
+*/
+
+/*
+
+#include <stdlib.h>
+#include <string.h>
+#include <cmqc.h>
+#include <cmqxc.h>
+
+*/
+import "C"
+import "unsafe"
+
+func init() {
+	copyCCDTUrlToC = func(mqcno *C.MQCNO, gocno *MQCNO) {
+		mqcno.CCDTUrlOffset = 0
+		if len(gocno.CCDTUrl) != 0 {
+			mqcno.CCDTUrlPtr = C.PMQCHAR(unsafe.Pointer(C.CString(gocno.CCDTUrl)))
+			mqcno.CCDTUrlLength = C.MQLONG(len(gocno.CCDTUrl))
+		} else {
+			mqcno.CCDTUrlPtr = nil
+			mqcno.CCDTUrlLength = 0
+		}
+	}
+
+	copyCCDTUrlFromC = func(gocno *MQCNO, mqcno *C.MQCNO) {
+		if mqcno.CCDTUrlPtr != nil {
+			C.free(unsafe.Pointer(mqcno.CCDTUrlPtr))
+		}
+	}
+}


### PR DESCRIPTION
## What
CCDTUrl handling separated to mqiMQCNO_v9.go to allow building against MQ v8.

## How
Hidden behind an "MQv8" build tag.

## Testing
Test with and without "-tags MQv8"

## Issues
See #4  for example.
