### PR TITLE
Allow compile on v8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/ibm-messaging/mq-golang

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -28,19 +28,19 @@ package ibmmq
 
 void freeCCDTUrl(MQCNO *mqcno) {
 #if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION >= MQCNO_VERSION_6
-	if (mqcno.CCDTUrlPtr != NULL) {
-		free(mqcno.CCDTUrlPtr);
+	if (mqcno->CCDTUrlPtr != NULL) {
+		free(mqcno->CCDTUrlPtr);
 	}
 #endif
 }
 
 void setCCDTUrl(MQCNO *mqcno, PMQCHAR url, MQLONG length) {
-#if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION == MQCNO_VERSION_6
-	mqcno.CCDTUrlOffset = 0;
-	mqcno.CCDTUrlPtr = NULL;
-	mqcno.CCDTUrlLength = length;
+#if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION >= MQCNO_VERSION_6
+	mqcno->CCDTUrlOffset = 0;
+	mqcno->CCDTUrlPtr = NULL;
+	mqcno->CCDTUrlLength = length;
 	if (url != NULL) {
-		mqcno.CCDTUrlPtr = PMQCHAR(url);
+		mqcno->CCDTUrlPtr = url;
 	}
 #else
 	if (url != NULL) {

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -26,6 +26,29 @@ package ibmmq
 #include <cmqc.h>
 #include <cmqxc.h>
 
+void freeCCDTUrl(MQCNO *mqcno) {
+#if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION == MQCNO_VERSION_6
+	if (mqcno.CCDTUrlPtr != NULL) {
+		free(mqcno.CCDTUrlPtr);
+	}
+#endif
+}
+
+void setCCDTUrl(MQCNO *mqcno, PMQCHAR url, MQLONG length) {
+#if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION == MQCNO_VERSION_6
+	mqcno.CCDTUrlOffset = 0;
+	mqcno.CCDTUrlPtr = NULL;
+	mqcno.CCDTUrlLength = length;
+	if (url != NULL) {
+		mqcno.CCDTUrlPtr = PMQCHAR(url);
+	}
+#else
+	if (url != NULL) {
+		free(url);
+	}
+#endif
+}
+
 */
 import "C"
 import "unsafe"
@@ -152,14 +175,7 @@ func copyCNOtoC(mqcno *C.MQCNO, gocno *MQCNO) {
 		mqcno.SecurityParmsPtr = nil
 	}
 
-	mqcno.CCDTUrlOffset = 0
-	if len(gocno.CCDTUrl) != 0 {
-		mqcno.CCDTUrlPtr = C.PMQCHAR(unsafe.Pointer(C.CString(gocno.CCDTUrl)))
-		mqcno.CCDTUrlLength = C.MQLONG(len(gocno.CCDTUrl))
-	} else {
-		mqcno.CCDTUrlPtr = nil
-		mqcno.CCDTUrlLength = 0
-	}
+	C.setCCDTUrl(mqcno, C.PMQCHAR(C.CString(gocno.CCDTUrl)), C.MQLONG(len(gocno.CCDTUrl)))
 	return
 }
 
@@ -187,8 +203,6 @@ func copyCNOfromC(mqcno *C.MQCNO, gocno *MQCNO) {
 		C.free(unsafe.Pointer(mqcno.SSLConfigPtr))
 	}
 
-	if mqcno.CCDTUrlPtr != nil {
-		C.free(unsafe.Pointer(mqcno.CCDTUrlPtr))
-	}
+	C.freeCCDTUrl(mqcno)
 	return
 }

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -36,6 +36,7 @@ void freeCCDTUrl(MQCNO *mqcno) {
 
 void setCCDTUrl(MQCNO *mqcno, PMQCHAR url, MQLONG length) {
 #if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION >= MQCNO_VERSION_6
+	mqcno->Version = MQCNO_VERSION_6;
 	mqcno->CCDTUrlOffset = 0;
 	mqcno->CCDTUrlPtr = NULL;
 	mqcno->CCDTUrlLength = length;
@@ -43,6 +44,7 @@ void setCCDTUrl(MQCNO *mqcno, PMQCHAR url, MQLONG length) {
 		mqcno->CCDTUrlPtr = url;
 	}
 #else
+	mqcno->Version = MQCNO_CURRENT_VERSION;
 	if (url != NULL) {
 		free(url);
 	}

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -188,7 +188,6 @@ func copyCNOfromC(mqcno *C.MQCNO, gocno *MQCNO) {
 		// Set memory to 0 for area that held a password
 		if mqcno.SecurityParmsPtr.CSPPasswordPtr != nil {
 			C.memset((unsafe.Pointer)(mqcno.SecurityParmsPtr.CSPPasswordPtr), 0, C.size_t(mqcno.SecurityParmsPtr.CSPPasswordLength))
-			C.free(unsafe.Pointer(mqcno.SecurityParmsPtr.CSPPasswordPtr))
 		}
 		C.free(unsafe.Pointer(mqcno.SecurityParmsPtr))
 	}

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -27,7 +27,7 @@ package ibmmq
 #include <cmqxc.h>
 
 void freeCCDTUrl(MQCNO *mqcno) {
-#if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION == MQCNO_VERSION_6
+#if defined(MQCNO_VERSION_6) && MQCNO_CURRENT_VERSION >= MQCNO_VERSION_6
 	if (mqcno.CCDTUrlPtr != NULL) {
 		free(mqcno.CCDTUrlPtr);
 	}

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -188,6 +188,7 @@ func copyCNOfromC(mqcno *C.MQCNO, gocno *MQCNO) {
 		// Set memory to 0 for area that held a password
 		if mqcno.SecurityParmsPtr.CSPPasswordPtr != nil {
 			C.memset((unsafe.Pointer)(mqcno.SecurityParmsPtr.CSPPasswordPtr), 0, C.size_t(mqcno.SecurityParmsPtr.CSPPasswordLength))
+			C.free(unsafe.Pointer(mqcno.SecurityParmsPtr.CSPPasswordPtr))
 		}
 		C.free(unsafe.Pointer(mqcno.SecurityParmsPtr))
 	}


### PR DESCRIPTION
No tag, just C preprocessor magic - another variant for #4, #57.

## What
CCDTUrl set/free moved to C functions.

## How
Create setCCDTUrl and freeCCDTUrl functions to set/free the CCDTUrl of the MQCNO struct.
These are in C land, so "#ifdef" chooses between "do nothing" (for v8) and "do as before" (for v9).

## Testing
Compile & test against v9, v8 MQ.

## Issues
#4, #57