### PR TITLE
Uniquename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## October 2018
+* Corrected heuristic for generating metric names
+
 ## August 2018
 * Added V9.1 constant definitions
 * Updated build comments

--- a/mqmetric/discover.go
+++ b/mqmetric/discover.go
@@ -681,8 +681,14 @@ func formatDescription(elem *MonElement) string {
 		} else if strings.Contains(s, "log_") {
 			/* Weird case where the log datatype is not MB or GB but should be bytes */
 			s = s + "_bytes"
-		} else {
-			s = s + "_count"
+		}
+
+		// There are some metrics that have both "count" and "byte count" in
+		// the descriptions. They were getting mapped to the same string, so
+		// we have to ensure uniqueness. We do not put "_count" on the
+		// metric name.
+		if (strings.Contains(elem.Description,"byte count")) {
+			s = s + "_bytes"
 		}
 	}
 


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [ ] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [ ] You have completed the PR template below:

## What

Changed heuristic for generating metric names from the Description. "count" and "byte count" were mapping to the same value. Newer versions of Prometheus were flagging the error.

## How

formatDescription() changed. This will not affect other monitor solutions that have chosen to map names explicitly rather than using this mechanism.

## Testing

Start the prometheus MQ monitor program and work with it directly (browser to http://localhost:9157) which shows errors

## Issues
#62 

