### PR TITLE
Add channel status discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## October 2018 - v3.0.0
+* Added functions to the mqmetric package to assist with collecting channel status
+* Better handle truncated messages when listing the queues that match a pattern
+
 ## October 2018
 * Corrected heuristic for generating metric names
 
@@ -7,7 +11,7 @@
 * Added V9.1 constant definitions
 * Updated build comments
 
-## May 2018
+## July 2018 - v2.0.0
 
 * Corrected package imports
 * Formatted go code with `go fmt`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository demonstrates how you can call IBM MQ from applications written in the Go language.
 
-> **NOTICE**: Please ensure that you use a dependency management tool such as [dep](https://github.com/golang/dep) or [Glide](http://glide.sh/), and add a specific version dependency.  The current content has been marked as version 1.0.0, and a new version with breaking changes will be released soon.  By using a dependency manager, you can continue to use the old version if you want to.
+> **NOTICE**: Please ensure that you use a dependency management tool such as [dep](https://github.com/golang/dep) or [Glide](http://glide.sh/), and add a specific version dependency.
 
 This repository previously contained sample programs that exported MQ statistics to some monitoring packages. These have now been moved to a new [GitHub repository called mq-metric-samples](https://github.com/ibm-messaging/mq-metric-samples).
 
@@ -20,6 +20,9 @@ The ibmmq directory contains a Go package, exposing an MQI-like interface.
 The intention is to give an API that is more natural for Go programmers than the common procedural MQI. For example, fixed length string arrays from the C API such as MQCHAR48 are represented by the native Go string type. Conversion between these types is handled within the ibmmq package itself, removing the need for Go programmers to know about it.
 
 A short program in the samples/mqitest directory gives an example of using this interface, to put and get messages and to subscribe to a topic.
+
+The mqmetric directory contains functions to help monitoring programs access MQ status and
+statistics. This package is not needed for general application programs.
 
 Feedback on the utility of this package, thoughts about whether it should be changed or extended are welcomed.
 
@@ -41,13 +44,16 @@ If you are unfamiliar with Go, the following steps can help create a working env
 
 * Set environment variables. Based on the previous lines,
 
-  ```export GOROOT=/usr/lib/golang```
-
-  ```export GOPATH=$HOME/gowork```
+```
+  export GOROOT=/usr/lib/golang
+  export GOPATH=$HOME/gowork
+```
 
 * If using a version of Go from after 2017, you must set environment variables to permit some compile/link flags. This is due to a security fix in the compiler.
 
-  ```export CGO_LDFLAGS_ALLOW="-Wl,-rpath.*"```
+```
+export CGO_LDFLAGS_ALLOW="-Wl,-rpath.*"
+```
 
 * Install the git client
 
@@ -55,14 +61,14 @@ If you are unfamiliar with Go, the following steps can help create a working env
 
 * Install the Go runtime and compiler. On Windows, the common directory is `c:\Go`
 * Ensure you have a gcc-based compiler, for example from the Cygwin distribution. I use the mingw variation, to ensure compiled code can be used on systems without Cygwin installed
-* Create a working directory. For example, ```mkdir c:\Gowork```
+* Create a working directory. For example, `mkdir c:\Gowork`
 * Set environment variables. Based on the previous lines,
 
-  ```set GOROOT=c:\Go```
-
-  ```set GOPATH=c:\Gowork```
-
-  ```set CC=x86_64-w64-mingw32-gcc.exe```
+```
+set GOROOT=c:\Go
+set GOPATH=c:\Gowork
+set CC=x86_64-w64-mingw32-gcc.exe
+```
 
 * The `CGO_LDFLAGS_ALLOW` variable is not needed on Windows
 * Install the git client
@@ -73,15 +79,15 @@ If you are unfamiliar with Go, the following steps can help create a working env
 * Change directory to the workspace you created earlier. (`cd $GOPATH`)
 * Use git to get a copy of the MQ components into a new directory in the workspace.
 
-  ```git clone https://github.com/ibm-messaging/mq-golang.git src/github.com/ibm-messaging/mq-golang```
+  `git clone https://github.com/ibm-messaging/mq-golang.git src/github.com/ibm-messaging/mq-golang`
 
 * Compile the `ibmmq` component:
 
-  ```go install ./src/github.com/ibm-messaging/mq-golang/ibmmq```
+  `go install ./src/github.com/ibm-messaging/mq-golang/ibmmq`
 
-* Compile the `mqmetric` component:
+* If you plan to use monitoring functions, then compile the `mqmetric` component:
 
-  ```go install ./src/github.com/ibm-messaging/mq-golang/mqmetric```
+  `go install ./src/github.com/ibm-messaging/mq-golang/mqmetric`
 
 * Follow the instructions in the [mq-metric-samples repository](https://github.com/ibm-messaging/mq-metric-samples) to compile the sample programs you are interested in.
 

--- a/ibmmq/mqistr.go
+++ b/ibmmq/mqistr.go
@@ -68,6 +68,8 @@ func MQItoString(class string, value int) string {
 
 	case "CC":
 		s = C.GoString(C.MQCC_STR(v))
+	case "CHT":
+		s = C.GoString(C.MQCHT_STR(v))
 	case "CMD":
 		s = C.GoString(C.MQCMD_STR(v))
 

--- a/mqmetric/channel.go
+++ b/mqmetric/channel.go
@@ -1,0 +1,389 @@
+/*
+Package mqmetric contains a set of routines common to several
+commands used to export MQ metrics to different backend
+storage mechanisms including Prometheus and InfluxDB.
+*/
+package mqmetric
+
+/*
+  Copyright (c) IBM Corporation 2016, 2018
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+   Contributors:
+     Mark Taylor - Initial Contribution
+*/
+
+/*
+Functions in this file use the DISPLAY CHSTATUS command to extract metrics
+about running MQ channels
+*/
+
+import (
+	"github.com/ibm-messaging/mq-golang/ibmmq"
+	"strings"
+)
+
+const (
+	ATTR_CHL_NAME     = "name"
+	ATTR_CHL_CONNNAME = "connname"
+	ATTR_CHL_JOBNAME  = "jobname"
+	ATTR_CHL_RQMNAME  = "rqmname"
+
+	ATTR_CHL_MESSAGES      = "messages"
+	ATTR_CHL_STATUS        = "status"
+	ATTR_CHL_STATUS_SQUASH = ATTR_CHL_STATUS + "_squash"
+	ATTR_CHL_TYPE          = "type"
+	ATTR_CHL_INSTANCE_TYPE = "instance_type"
+
+	SQUASH_CHL_STATUS_STOPPED    = 0
+	SQUASH_CHL_STATUS_TRANSITION = 1
+	SQUASH_CHL_STATUS_RUNNING    = 2
+)
+
+var ChannelStatus StatusSet
+var attrsInit = false
+var channelsSeen map[string]bool
+
+/*
+Unlike the statistics produced via a topic, there is no discovery
+of the attributes available in object STATUS queries. There is also
+no discovery of descriptions for them. So this function hardcodes the
+attributes we are going to look for and gives the associated descriptive
+text. The elements can be expanded later; just trying to give a starting point
+for now.
+*/
+func ChannelInitAttributes() {
+	if attrsInit {
+		return
+	}
+	ChannelStatus.Attributes = make(map[string]*StatusAttribute)
+
+	// These fields are used to construct the key to the per-channel map values and
+	// as tags to uniquely identify a channel instance
+	attr := ATTR_CHL_NAME
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Channel Name", -1)
+	attr = ATTR_CHL_RQMNAME
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Remote Queue Manager Name", -1)
+	attr = ATTR_CHL_JOBNAME
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "MCA Job Name", -1)
+	attr = ATTR_CHL_CONNNAME
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Connection Name", -1)
+
+	// These are the integer status fields that are of interest
+	attr = ATTR_CHL_MESSAGES
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Messages (API Calls for SVRCONN)", ibmmq.MQIACH_MSGS)
+	ChannelStatus.Attributes[attr].delta = true // We have to manage the differences as MQ reports cumulative values
+
+	attr = ATTR_CHL_STATUS
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Channel Status", ibmmq.MQIACH_CHANNEL_STATUS)
+	attr = ATTR_CHL_TYPE
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Channel Type", ibmmq.MQIACH_CHANNEL_TYPE)
+	attr = ATTR_CHL_INSTANCE_TYPE
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Channel Instance Type", ibmmq.MQIACH_CHANNEL_INSTANCE_TYPE)
+
+	// This is the same attribute as earlier, except that we indicate the values are to be modified in
+	// a special way.
+	attr = ATTR_CHL_STATUS_SQUASH
+	ChannelStatus.Attributes[attr] = newStatusAttribute(attr, "Channel Status - Simplified", ibmmq.MQIACH_CHANNEL_STATUS)
+	ChannelStatus.Attributes[attr].squash = true
+	attrsInit = true
+}
+
+// If we need to list the channels that match a pattern. Not needed for
+// the status queries as they (unlike the pub/sub resource stats) accept
+// patterns in the
+func InquireChannels(patterns string) ([]string, error) {
+	ChannelInitAttributes()
+	return inquireObjects(patterns, ibmmq.MQOT_CHANNEL)
+}
+
+func CollectChannelStatus(patterns string) error {
+	var err error
+	channelsSeen = make(map[string]bool) // Record which channels have been seen in this period
+
+	ChannelInitAttributes()
+
+	// Empty any collected values
+	for k := range ChannelStatus.Attributes {
+		ChannelStatus.Attributes[k].Values = make(map[string]*StatusValue)
+	}
+
+	channelPatterns := strings.Split(patterns, ",")
+	if len(channelPatterns) == 0 {
+		return nil
+	}
+
+	for _, pattern := range channelPatterns {
+		pattern = strings.TrimSpace(pattern)
+		if len(pattern) == 0 {
+			continue
+		}
+
+		// This would allow us to extract SAVED information too
+		err = collectChannelStatus(pattern, ibmmq.MQOT_CURRENT_CHANNEL)
+
+	}
+
+	// Need to clean out the prevValues elements to stop short-lived channels
+	// building up in the map
+	for a, _ := range ChannelStatus.Attributes {
+		if ChannelStatus.Attributes[a].delta {
+			m := ChannelStatus.Attributes[a].prevValues
+			for key, _ := range m {
+				if _, ok := channelsSeen[key]; ok {
+					// Leave it in the map
+				} else {
+					// need to delete it from the map
+					delete(m, key)
+				}
+			}
+		}
+	}
+	return err
+
+}
+
+// Issue the INQUIRE_CHANNEL_STATUS command for a channel or wildcarded channel name
+// Collect the responses and build up the statistics
+func collectChannelStatus(pattern string, instanceType int32) error {
+	var err error
+	var datalen int
+
+	putmqmd := ibmmq.NewMQMD()
+	pmo := ibmmq.NewMQPMO()
+
+	pmo.Options = ibmmq.MQPMO_NO_SYNCPOINT
+	pmo.Options |= ibmmq.MQPMO_NEW_MSG_ID
+	pmo.Options |= ibmmq.MQPMO_NEW_CORREL_ID
+	pmo.Options |= ibmmq.MQPMO_FAIL_IF_QUIESCING
+
+	putmqmd.Format = "MQADMIN"
+	putmqmd.ReplyToQ = statusReplyQObj.Name
+	putmqmd.MsgType = ibmmq.MQMT_REQUEST
+	putmqmd.Report = ibmmq.MQRO_PASS_DISCARD_AND_EXPIRY
+
+	buf := make([]byte, 0)
+	// Empty replyQ in case any left over from previous errors
+	for ok := true; ok; {
+		getmqmd := ibmmq.NewMQMD()
+		gmo := ibmmq.NewMQGMO()
+		gmo.Options = ibmmq.MQGMO_NO_SYNCPOINT
+		gmo.Options |= ibmmq.MQGMO_FAIL_IF_QUIESCING
+		gmo.Options |= ibmmq.MQGMO_NO_WAIT
+		gmo.Options |= ibmmq.MQGMO_CONVERT
+		gmo.Options |= ibmmq.MQGMO_ACCEPT_TRUNCATED_MSG
+		_, err = statusReplyQObj.Get(getmqmd, gmo, buf)
+
+		if err != nil && err.(*ibmmq.MQReturn).MQCC == ibmmq.MQCC_FAILED {
+			ok = false
+		}
+	}
+	buf = make([]byte, 0)
+
+	cfh := ibmmq.NewMQCFH()
+
+	// Can allow all the other fields to default
+	cfh.Command = ibmmq.MQCMD_INQUIRE_CHANNEL_STATUS
+
+	// Add the parameters one at a time into a buffer
+	pcfparm := new(ibmmq.PCFParameter)
+	pcfparm.Type = ibmmq.MQCFT_STRING
+	pcfparm.Parameter = ibmmq.MQCACH_CHANNEL_NAME
+	pcfparm.String = []string{pattern}
+	cfh.ParameterCount++
+	buf = append(buf, pcfparm.Bytes()...)
+
+	// Add the parameters one at a time into a buffer
+	pcfparm = new(ibmmq.PCFParameter)
+	pcfparm.Type = ibmmq.MQCFT_INTEGER
+	pcfparm.Parameter = ibmmq.MQIACH_CHANNEL_INSTANCE_TYPE
+	pcfparm.Int64Value = []int64{int64(instanceType)}
+	cfh.ParameterCount++
+	buf = append(buf, pcfparm.Bytes()...)
+
+	// Once we know the total number of parameters, put the
+	// CFH header on the front of the buffer.
+	buf = append(cfh.Bytes(), buf...)
+
+	// And now put the command to the queue
+	err = cmdQObj.Put(putmqmd, pmo, buf)
+	if err != nil {
+		return err
+
+	}
+
+	// Now get the responses - loop until all have been received (one
+	// per channel) or we run out of time
+	replyBuf := make([]byte, 10240)
+	for allReceived := false; !allReceived; {
+		getmqmd := ibmmq.NewMQMD()
+		gmo := ibmmq.NewMQGMO()
+		gmo.Options = ibmmq.MQGMO_NO_SYNCPOINT
+		gmo.Options |= ibmmq.MQGMO_FAIL_IF_QUIESCING
+		gmo.Options |= ibmmq.MQGMO_WAIT
+		gmo.Options |= ibmmq.MQGMO_CONVERT
+		gmo.WaitInterval = 3 * 1000 // 3 seconds
+
+		datalen, err = statusReplyQObj.Get(getmqmd, gmo, replyBuf)
+		if err == nil {
+			cfh, offset := ibmmq.ReadPCFHeader(replyBuf)
+
+			if cfh.Control == ibmmq.MQCFC_LAST {
+				allReceived = true
+			}
+			if cfh.Reason != ibmmq.MQRC_NONE {
+				continue
+			}
+			key := parseData(cfh, replyBuf[offset:datalen])
+			channelsSeen[key] = true
+		}
+	}
+
+	return err
+}
+
+// Given a PCF response message, parse it to extract the desired statistics
+func parseData(cfh *ibmmq.MQCFH, buf []byte) string {
+	var elem *ibmmq.PCFParameter
+
+	chlName := ""
+	connName := ""
+	jobName := ""
+	rqmName := ""
+	key := ""
+
+	parmAvail := true
+	bytesRead := 0
+	offset := 0
+	datalen := len(buf)
+	if cfh.ParameterCount == 0 {
+		return ""
+	}
+
+	// Parse it once to extract the fields that are needed for the map key
+	for parmAvail && cfh.CompCode != ibmmq.MQCC_FAILED {
+		elem, bytesRead = ibmmq.ReadPCFParameter(buf[offset:])
+		offset += bytesRead
+		// Have we now reached the end of the message
+		if offset >= datalen {
+			parmAvail = false
+		}
+
+		switch elem.Parameter {
+		case ibmmq.MQCACH_CHANNEL_NAME:
+			chlName = strings.TrimSpace(elem.String[0])
+		case ibmmq.MQCACH_CONNECTION_NAME:
+			connName = strings.TrimSpace(elem.String[0])
+		case ibmmq.MQCACH_MCA_JOB_NAME:
+			jobName = strings.TrimSpace(elem.String[0])
+		case ibmmq.MQCA_REMOTE_Q_MGR_NAME:
+			rqmName = strings.TrimSpace(elem.String[0])
+		}
+	}
+
+	// Create a unique key for this channel instance
+	key = chlName + "/" + connName + "/" + jobName
+
+	ChannelStatus.Attributes[ATTR_CHL_NAME].Values[key] = newStatusValueString(chlName)
+	ChannelStatus.Attributes[ATTR_CHL_CONNNAME].Values[key] = newStatusValueString(connName)
+	ChannelStatus.Attributes[ATTR_CHL_RQMNAME].Values[key] = newStatusValueString(rqmName)
+	ChannelStatus.Attributes[ATTR_CHL_JOBNAME].Values[key] = newStatusValueString(jobName)
+
+	// And then re-parse the message so we can store the metrics now knowing the map key
+	parmAvail = true
+	offset = 0
+	for parmAvail && cfh.CompCode != ibmmq.MQCC_FAILED {
+		elem, bytesRead = ibmmq.ReadPCFParameter(buf[offset:])
+		offset += bytesRead
+		// Have we now reached the end of the message
+		if offset >= datalen {
+			parmAvail = false
+		}
+
+		// Look at the Parameter and loop through all the possible status
+		// attributes to find it.We don't break from the loop after finding a match
+		// because there might be more than one attribute associated with the
+		// attribute (in particular status/status_squash)
+		if elem.Type == ibmmq.MQCFT_INTEGER || elem.Type == ibmmq.MQCFT_INTEGER64 {
+			v := elem.Int64Value[0]
+
+			for attr, _ := range ChannelStatus.Attributes {
+				if ChannelStatus.Attributes[attr].pcfAttr == elem.Parameter {
+					if ChannelStatus.Attributes[attr].delta {
+						// If we have already got a value for this attribute and channel
+						// then use it to create the delta. Otherwise make the initial
+						// value 0.
+						if prevVal, ok := ChannelStatus.Attributes[attr].prevValues[key]; ok {
+							ChannelStatus.Attributes[attr].Values[key] = newStatusValueInt64(v - prevVal)
+						} else {
+							ChannelStatus.Attributes[attr].Values[key] = newStatusValueInt64(0)
+						}
+						ChannelStatus.Attributes[attr].prevValues[key] = v
+					} else {
+						// Return the actual number
+						ChannelStatus.Attributes[attr].Values[key] = newStatusValueInt64(v)
+					}
+				}
+			}
+		}
+	}
+
+	return key
+}
+
+// Return a standardised value. If the attribute indicates that something
+// special has to be done, then do that. Otherwise just make sure it's a non-negative
+// value of the correct datatype
+func ChannelNormalise(attr *StatusAttribute, v int64) float64 {
+	var f float64
+
+	if attr.squash {
+		switch attr.pcfAttr {
+
+		case ibmmq.MQIACH_CHANNEL_STATUS:
+			v32 := int32(v)
+			switch v32 {
+			case ibmmq.MQCHS_INACTIVE,
+				ibmmq.MQCHS_DISCONNECTED,
+				ibmmq.MQCHS_STOPPED,
+				ibmmq.MQCHS_PAUSED:
+				f = float64(SQUASH_CHL_STATUS_STOPPED)
+
+			case ibmmq.MQCHS_BINDING,
+				ibmmq.MQCHS_STARTING,
+				ibmmq.MQCHS_STOPPING,
+				ibmmq.MQCHS_RETRYING,
+				ibmmq.MQCHS_REQUESTING,
+				ibmmq.MQCHS_INITIALIZING,
+				ibmmq.MQCHS_SWITCHING:
+				f = float64(SQUASH_CHL_STATUS_TRANSITION)
+			case ibmmq.MQCHS_RUNNING:
+				f = float64(SQUASH_CHL_STATUS_RUNNING)
+			default:
+				f = float64(SQUASH_CHL_STATUS_STOPPED)
+			}
+		default:
+			f = float64(v)
+			if f < 0 {
+				f = 0
+			}
+		}
+	} else {
+		f = float64(v)
+		if f < 0 {
+			f = 0
+		}
+	}
+	return f
+}

--- a/mqmetric/mqif.go
+++ b/mqmetric/mqif.go
@@ -1,7 +1,7 @@
 package mqmetric
 
 /*
-  Copyright (c) IBM Corporation 2016
+  Copyright (c) IBM Corporation 2016, 2018
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -31,16 +31,15 @@ import (
 )
 
 var (
-	qMgr      ibmmq.MQQueueManager
-	cmdQObj   ibmmq.MQObject
-	replyQObj ibmmq.MQObject
-	statsQObj ibmmq.MQObject
-	getBuffer = make([]byte, 32768)
+	qMgr            ibmmq.MQQueueManager
+	cmdQObj         ibmmq.MQObject
+	replyQObj       ibmmq.MQObject
+	statusReplyQObj ibmmq.MQObject
+	getBuffer       = make([]byte, 32768)
 
-	qmgrConnected     = false
-	queuesOpened      = false
-	statsQueuesOpened = false
-	subsOpened        = false
+	qmgrConnected = false
+	queuesOpened  = false
+	subsOpened    = false
 )
 
 type ConnectionConfig struct {
@@ -55,14 +54,6 @@ opens both the command queue and a dynamic reply queue
 to be used for all responses including the publications
 */
 func InitConnection(qMgrName string, replyQ string, cc *ConnectionConfig) error {
-	return InitConnectionStats(qMgrName, replyQ, "", cc)
-}
-
-/*
-InitConnectionStats is the same as InitConnection with the addition
-of a call to open the queue manager statistics queue.
-*/
-func InitConnectionStats(qMgrName string, replyQ string, statsQ string, cc *ConnectionConfig) error {
 	var err error
 	gocno := ibmmq.NewMQCNO()
 	gocsp := ibmmq.NewMQCSP()
@@ -100,19 +91,7 @@ func InitConnectionStats(qMgrName string, replyQ string, statsQ string, cc *Conn
 
 	}
 
-	// MQOPEN of the statistics queue
-	if err == nil && statsQ != "" {
-		mqod := ibmmq.NewMQOD()
-		openOptions := ibmmq.MQOO_INPUT_AS_Q_DEF | ibmmq.MQOO_FAIL_IF_QUIESCING
-		mqod.ObjectType = ibmmq.MQOT_Q
-		mqod.ObjectName = statsQ
-		statsQObj, err = qMgr.Open(mqod, openOptions)
-		if err == nil {
-			statsQueuesOpened = true
-		}
-	}
-
-	// MQOPEN of a reply queue
+	// MQOPEN of a reply queue also used for subscription delivery
 	if err == nil {
 		mqod := ibmmq.NewMQOD()
 		openOptions := ibmmq.MQOO_INPUT_AS_Q_DEF | ibmmq.MQOO_FAIL_IF_QUIESCING
@@ -122,6 +101,15 @@ func InitConnectionStats(qMgrName string, replyQ string, statsQ string, cc *Conn
 		if err == nil {
 			queuesOpened = true
 		}
+	}
+
+	// MQOPEN of a second reply queue used for status polling
+	if err == nil {
+		mqod := ibmmq.NewMQOD()
+		openOptions := ibmmq.MQOO_INPUT_AS_Q_DEF | ibmmq.MQOO_FAIL_IF_QUIESCING
+		mqod.ObjectType = ibmmq.MQOT_Q
+		mqod.ObjectName = replyQ
+		statusReplyQObj, err = qMgr.Open(mqod, openOptions)
 	}
 
 	if err != nil {
@@ -151,10 +139,7 @@ func EndConnection() {
 	if queuesOpened {
 		cmdQObj.Close(0)
 		replyQObj.Close(0)
-	}
-
-	if statsQueuesOpened {
-		statsQObj.Close(0)
+		statusReplyQObj.Close(0)
 	}
 
 	// MQDISC regardless of other errors

--- a/mqmetric/status.go
+++ b/mqmetric/status.go
@@ -1,0 +1,79 @@
+/*
+Package mqmetric contains a set of routines common to several
+commands used to export MQ metrics to different backend
+storage mechanisms including Prometheus and InfluxDB.
+*/
+package mqmetric
+
+/*
+  Copyright (c) IBM Corporation 2016, 2018
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+   Contributors:
+     Mark Taylor - Initial Contribution
+*/
+
+/*
+This file defines types and constructors for elements related to status
+of MQ objects that are retrieved via polling commands such as DISPLAY CHSTATUS
+*/
+
+type StatusAttribute struct {
+	Description string
+	MetricName  string
+	pcfAttr     int32
+	squash      bool
+	delta       bool
+	Values      map[string]*StatusValue
+	prevValues  map[string]int64
+}
+
+type StatusSet struct {
+	Attributes map[string]*StatusAttribute
+}
+
+// All we care about for attributes are ints and strings. Other complex
+// PCF datatypes are not currently going to be returned through this mechanism
+type StatusValue struct {
+	IsInt64     bool
+	ValueInt64  int64
+	ValueString string
+}
+
+// Initialise with default values.
+func newStatusAttribute(n string, d string, p int32) *StatusAttribute {
+	s := new(StatusAttribute)
+	s.MetricName = n
+	s.Description = d
+	s.pcfAttr = p
+	s.squash = false
+	s.delta = false
+	s.Values = make(map[string]*StatusValue)
+	s.prevValues = make(map[string]int64)
+	return s
+}
+
+func newStatusValueInt64(v int64) *StatusValue {
+	s := new(StatusValue)
+	s.ValueInt64 = v
+	s.IsInt64 = true
+	return s
+}
+
+func newStatusValueString(v string) *StatusValue {
+	s := new(StatusValue)
+	s.ValueString = v
+	s.IsInt64 = false
+	return s
+}


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [ ] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [ ] You have completed the PR template below:

## What

Add a set of PCF operations for DISPLAY CHSTATUS and extracting the metrics from responses. Users
wanting to see at least whether channels were running or not

## How

New module for channel information; structured so similar QSTATUS or TPSTATUS could be added

## Testing

Used a modified Prometheus monitor agent (to be released next) to see the stats

## Issues

See #25
