### PR TITLE
Int32fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For example,
 
    export CGO_LDFLAGS="-L$MQ_INSTALLATION_PATH/lib64 -Wl,rpath=$MQ_INSTALLATION_PATH/lib64"
        or on Darwin
-   export CGO_LDFLAGS="-L$MQ_INSTALLATION_PATH/lib64 -Wl,rpath,$MQ_INSTALLATION_PATH/lib64"
+   export CGO_LDFLAGS="-L$MQ_INSTALLATION_PATH/lib64 -Wl,-rpath,$MQ_INSTALLATION_PATH/lib64"
 ```
 
 * Compile the `ibmmq` component:

--- a/ibmmq/mqi.go
+++ b/ibmmq/mqi.go
@@ -1232,8 +1232,8 @@ func (handle *MQMessageHandle) InqMP(goimpo *MQIMPO, gopd *MQPD, name string) (s
 		p := (*C.MQBYTE)(propertyPtr)
 		propertyValue = (int16)(*p)
 	case C.MQTYPE_INT32:
-		p := (*C.MQINT16)(propertyPtr)
-		propertyValue = (int16)(*p)
+		p := (*C.MQINT32)(propertyPtr)
+		propertyValue = (int32)(*p)
 	case C.MQTYPE_INT64:
 		p := (*C.MQINT64)(propertyPtr)
 		propertyValue = (int64)(*p)


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [X] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [X] You have completed the PR template below:

## What

Minor update for readme, Darwin needs dash for rpath
Fixed issue with int16 being used on int32 header conversions

Wasn't sure if this was worth putting in the changelog.

## How

Noticed the conversion was turning int32 into int16, and replaced the types.

## Testing

Existing tests pass, no new tests added. Tests in dependent repo pass.

## Issues

https://github.com/ibm-messaging/mq-golang/issues/83
