### PR TITLE
SSL Fix for #87

### DIFF
--- a/ibmmq/mqi.go
+++ b/ibmmq/mqi.go
@@ -207,7 +207,8 @@ func Connx(goQMgrName string, gocno *MQCNO) (MQQueueManager, error) {
 		verb: "MQCONNX",
 	}
 
-	if mqcc != C.MQCC_OK {
+	// Repeated SSL connects may receive MQRC_SSL_ALREADY_INITIALIZED, with a valid hConn
+	if mqcc != C.MQCC_OK && !(mqreturn.MQCC == MQCC_WARNING && mqreturn.MQRC == MQRC_SSL_ALREADY_INITIALIZED && qMgr.hConn > 0) {
 		return qMgr, mqreturn
 	}
 

--- a/samples/amqsconntls.go
+++ b/samples/amqsconntls.go
@@ -1,0 +1,122 @@
+/*
+This is a short sample to show how to connect to a remote
+queue manager in a Go program using SSL without requiring external
+client configuration such as a CCDT. Only the basic
+parameters are needed here - channel name and connection information -
+along with the queue manager name.
+
+For example, run as
+   amqsconntls QMGR1 "SYSTEM.DEF.SVRCONN" "myhost.example.com(1414)" /mycerts/client/key
+
+If the MQSAMP_USER_ID environment variable is set, then a userid/password
+flow is also made to authenticate to the queue manager.
+
+The keypath should point to directory/fileprefix where the directory contains fileprefix.key and
+fileprefix.sth.
+
+If an error occurs, the error is reported.
+*/
+package main
+
+/*
+  Copyright (c) IBM Corporation 2017, 2018
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+   Contributors:
+     Mark Taylor - Initial Contribution
+*/
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ibm-messaging/mq-golang/ibmmq"
+)
+
+func main() {
+	var qMgrName string
+	var err error
+	var qMgr ibmmq.MQQueueManager
+	var rc int
+
+	if len(os.Args) != 5 {
+		fmt.Println("amqsconn <qmgrname> <channelname> <conname>")
+		fmt.Println("")
+		fmt.Println("For example")
+		fmt.Println("  amqsconntls QMGR1 \"SYSTEM.DEF.SVRCONN\" \"myhost.example.com(1414)\" /mycerts/client/key")
+		fmt.Println("All parameters are required.")
+		os.Exit(1)
+	}
+
+	// Which queue manager do we want to connect to
+	qMgrName = os.Args[1]
+
+	// Allocate the MQCNO and MQCD structures needed for the CONNX call.
+	cno := ibmmq.NewMQCNO()
+	cd := ibmmq.NewMQCD()
+
+	// Fill in required fields in the MQCD channel definition structure
+	cd.ChannelName = os.Args[2]
+	cd.ConnectionName = os.Args[3]
+
+	// Reference the CD structure from the CNO and indicate that we definitely want to
+	// use the client connection method.
+	cno.ClientConn = cd
+	cno.Options = ibmmq.MQCNO_CLIENT_BINDING
+
+	// Also fill in the userid and password if the MQSAMP_USER_ID
+	// environment variable is set. This is the same variable used by the C
+	// sample programs such as amqsput shipped with the MQ product.
+	userID := os.Getenv("MQSAMP_USER_ID")
+	if userID != "" {
+		scanner := bufio.NewScanner(os.Stdin)
+		csp := ibmmq.NewMQCSP()
+		csp.AuthenticationType = ibmmq.MQCSP_AUTH_USER_ID_AND_PWD
+		csp.UserId = userID
+
+		fmt.Printf("Enter password for qmgr %s: \n", qMgrName)
+		// For simplicity (it doesn't help with understanding the MQ parts of this program)
+		// don't try to do anything special like turning off console echo for the password input
+		scanner.Scan()
+		csp.Password = scanner.Text()
+
+		// Make the CNO refer to the CSP structure so it gets used during the connection
+		cno.SecurityParms = csp
+	}
+
+	cd.SSLCipherSpec = "TLS_RSA_WITH_AES_128_CBC_SHA256"
+	tlsParams := ibmmq.NewMQSCO()
+	tlsParams.KeyRepository = os.Args[4]
+	cno.SSLConfig = tlsParams
+
+	// And now we can try to connect. Wait a short time before disconnecting.
+	qMgr, err = ibmmq.Connx(qMgrName, cno)
+	if err == nil {
+		fmt.Printf("TLS connection to %s succeeded.\n", qMgrName)
+		d, _ := time.ParseDuration("5s")
+		time.Sleep(d)
+		qMgr.Disc() // Ignore errors from disconnect as we can't do much about it anyway
+		rc = 0
+	} else {
+		fmt.Printf("TLS connection to %s failed.\n", qMgrName)
+		fmt.Println(err)
+		rc = int(err.(*ibmmq.MQReturn).MQCC)
+	}
+
+	fmt.Println("Done.")
+	os.Exit(rc)
+
+}


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [X ] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [X ] You have completed the PR template below:

## What

Added a double check in the connx code for a MQRC_SSL_ALREADY_INITIALIZED warning which can occur if SSL configs are matching but reused.

## How

Discovered that you can't make 2 SSL connections, even if the settings are the same.

## Testing

Tested manually by updating the new TLS sample to loop.

## Issues

https://github.com/ibm-messaging/mq-golang/issues/87
