### PR TITLE
Make callbacks explicitly pass the hConn (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Newest updates are at the top of this file.
 
+## March 26 2019
+* BREAKING API: Add hConn to callback function
+* Callbacks not setting hConn correctly (#93)
+
 ## March 20 2019 - v4.0.0
 * Update for MQ 9.1.2 - ApplName now settable during Connect
 * BREAKING API: deprecated Inq()/MQINQ implementation replaced.

--- a/ibmmq/mqicb.go
+++ b/ibmmq/mqicb.go
@@ -38,7 +38,7 @@ import (
 )
 
 // The user's callback function must match this signature
-type MQCB_FUNCTION func(*MQObject, *MQMD, *MQGMO, []byte, *MQCBC, *MQReturn)
+type MQCB_FUNCTION func(*MQQueueManager, *MQObject, *MQMD, *MQGMO, []byte, *MQCBC, *MQReturn)
 
 // Need to keep references to the user's callback function and some other
 // structure elements which do not map to the C functions, or do not need to
@@ -119,6 +119,9 @@ func MQCALLBACK_Go(hConn C.MQHCONN, mqmd *C.MQMD, mqgmo *C.MQGMO, mqBuffer C.PMQ
 	}
 
 	if ok {
+		if gogmo.MsgHandle.hMsg != C.MQHM_NONE {
+			gogmo.MsgHandle.qMgr = cbHObj.qMgr
+		}
 
 		gocbc.CallbackArea = info.callbackArea
 		gocbc.ConnectionArea = info.connectionArea
@@ -126,7 +129,7 @@ func MQCALLBACK_Go(hConn C.MQHCONN, mqmd *C.MQMD, mqgmo *C.MQGMO, mqBuffer C.PMQ
 		// Get the data
 		b := C.GoBytes(unsafe.Pointer(mqBuffer), C.int(mqcbc.DataLength))
 		// And finally call the user function
-		info.callbackFunction(cbHObj, gomd, gogmo, b, gocbc, mqreturn)
+		info.callbackFunction(cbHObj.qMgr, cbHObj, gomd, gogmo, b, gocbc, mqreturn)
 	}
 }
 


### PR DESCRIPTION
Add hConn to callback

Please ensure all items are complete before opening.

- [ ] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [ ] You have completed the PR template below:

## What

What was changed

## How

How the change was implemented or reasoning behind it

## Testing

How to test your changes work, not required for documentation changes.

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
