### PR TITLE
Add IsValid() method to MQQueueManager

### DIFF
--- a/ibmmq/ibmmq_test.go
+++ b/ibmmq/ibmmq_test.go
@@ -289,3 +289,15 @@ func TestRoundTo4(t *testing.T) {
 		}
 	}
 }
+
+func TestHConnValid(t *testing.T) {
+	valid := MQQueueManager{hConn: 0}
+	if !valid.IsValid() {
+		t.Error("MQHC_DEF_HCONN: expected IsValid true, got false")
+	}
+
+	invalid := MQQueueManager{hConn: -1}
+	if invalid.IsValid() {
+		t.Error("MQHC_UNUSABLE_HCONN: expected IsValid false, got true")
+	}
+}

--- a/ibmmq/mqi.go
+++ b/ibmmq/mqi.go
@@ -607,6 +607,15 @@ func (x *MQQueueManager) Put1(good *MQOD, gomd *MQMD,
 
 }
 
+// IsValid returns FALSE if the underlying hConn is
+// MQHC_UNUSABLE_HCONN otherwise TRUE
+func (x *MQQueueManager) IsValid() bool {
+	if x.hConn == C.MQHC_UNUSABLE_HCONN {
+		return false
+	}
+	return true
+}
+
 /*
 Get a message from a queue
 The length of the retrieved message is returned.


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [X ] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [X ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [X ] You have completed the PR template below:

## What

Added an `IsValid` method to the `MQQueueManager` type

## How

Since the underlying hConn in `MQQueueManager` is not exported a convenience method is added to check if the hConn is still valid or has been set to `MQHC_UNUSABLE_HCONN`

## Testing

Test is added in package test suite.

## Issues

N/A
