### PR TITLE
Fix panics in NewMQDLH

### DIFF
--- a/ibmmq/ibmmq_test.go
+++ b/ibmmq/ibmmq_test.go
@@ -289,3 +289,33 @@ func TestRoundTo4(t *testing.T) {
 		}
 	}
 }
+
+func TestNewMQDLHWithNilMQMD(t *testing.T) {
+	dlh := NewMQDLH(nil)
+	if dlh == nil {
+		t.Logf("Expected the MQDLH to not be nil, Got: %v", dlh)
+		t.Fail()
+	}
+}
+
+func TestNewMQDLHWithMQMD(t *testing.T) {
+	mqmd := NewMQMD()
+	mqmd.PutDate = "20060102"
+	mqmd.PutTime = "150405.00"
+
+	dlh := NewMQDLH(mqmd)
+	if dlh == nil {
+		t.Logf("Expected the MQDLH to not be nil. Got: %v", dlh)
+		t.Fail()
+	}
+
+	if dlh.PutDate != mqmd.PutDate {
+		t.Logf("PutDate is wrong. Expected: %q. Got: %q", mqmd.PutDate, dlh.PutDate)
+		t.Fail()
+	}
+
+	if dlh.PutTime != mqmd.PutTime {
+		t.Logf("PutTime is wrong. Expected: %q. Got: %q", mqmd.PutTime, dlh.PutTime)
+		t.Fail()
+	}
+}

--- a/ibmmq/mqiDLH.go
+++ b/ibmmq/mqiDLH.go
@@ -53,8 +53,6 @@ func NewMQDLH(md *MQMD) *MQDLH {
 	dlh.CodedCharSetId = MQCCSI_UNDEFINED
 	dlh.PutApplType = 0
 	dlh.PutApplName = ""
-	dlh.PutTime = md.PutTime // Copy over the original put timestamp
-	dlh.PutDate = md.PutDate
 	dlh.Format = ""
 	dlh.DestQName = ""
 	dlh.DestQMgrName = ""
@@ -62,6 +60,8 @@ func NewMQDLH(md *MQMD) *MQDLH {
 	dlh.strucLength = int(MQDLH_CURRENT_LENGTH)
 
 	if md != nil {
+		dlh.PutTime = md.PutTime // Copy over the original put timestamp
+		dlh.PutDate = md.PutDate
 		dlh.Encoding = md.Encoding
 		if md.CodedCharSetId == MQCCSI_DEFAULT {
 			dlh.CodedCharSetId = MQCCSI_INHERIT


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-golang/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [x] You have completed the PR template below:

## What

https://github.com/ibm-messaging/mq-golang/blob/fa8d9eb047f8ea5cd87d9c237e6e52d65f32d8d5/ibmmq/mqiDLH.go#L134 causes `NewMQDLH` to panic as it's trying to access the `PutDate` and `PutTime` fields of a `nil` struct.

## How

Copy over the original put timestamp from the MQMD struct only if it's not null

## Testing

Tests have been added to assert the expected behaviour. Without the code change, the code would panic.

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
