### PR TITLE
Fix a data race in getAttrInfo

### DIFF
--- a/ibmmq/ibmmq_test.go
+++ b/ibmmq/ibmmq_test.go
@@ -319,3 +319,22 @@ func TestNewMQDLHWithMQMD(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestGetAttrInfoConcurrentCalls(t *testing.T) {
+	// NOTE: This test should be run with `go test -race`.
+	attrs := []int32{
+		MQCA_BACKOUT_REQ_Q_NAME,
+		MQIA_BACKOUT_THRESHOLD,
+	}
+	count := 1_000
+	doneCh := make(chan struct{}, count)
+	for i := 0; i < count; i++ {
+		go func() {
+			getAttrInfo(attrs)
+			doneCh <- struct{}{}
+		}()
+	}
+	for i := 0; i < count; i++ {
+		<-doneCh
+	}
+}

--- a/ibmmq/mqiattrs.go
+++ b/ibmmq/mqiattrs.go
@@ -61,6 +61,7 @@ import "C"
 import (
 	"fmt"
 	"os"
+	"sync"
 )
 
 /*
@@ -130,7 +131,7 @@ var mqInqLength = map[int32]int32{
 	C.MQCA_XMIT_Q_NAME:           C.MQ_Q_NAME_LENGTH,
 }
 
-var charAttrsAdded = false
+var charAttrsAddedOnce sync.Once
 
 /*
  * Return how many char & int attributes are in the list of selectors, and the
@@ -141,7 +142,7 @@ func getAttrInfo(attrs []int32) (int, int, int) {
 	var charAttrCount = 0
 	var intAttrCount = 0
 
-	if !charAttrsAdded {
+	charAttrsAddedOnce.Do(func() {
 		maxNewAttrs := C.MAX_NEW_MQCA_ATTRS
 		attrVals := make([]C.MQLONG, maxNewAttrs)
 		attrLens := make([]C.MQLONG, maxNewAttrs)
@@ -155,8 +156,7 @@ func getAttrInfo(attrs []int32) (int, int, int) {
 		for i := 0; i < addedAttrs; i++ {
 			mqInqLength[int32(attrVals[i])] = int32(attrLens[i])
 		}
-		charAttrsAdded = true
-	}
+	})
 
 	for i := 0; i < len(attrs); i++ {
 		if v, ok := mqInqLength[attrs[i]]; ok {


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-golang/DCO1.1.txt)
- [x] You have added tests for any code changes - test needs to be run with `go test -race`
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md) - `CHANGELOG.md` should probably only get updated once there's a new version that includes this fix.
- [x] You have completed the PR template below:

## What

Fixes an issue raised in https://github.com/ibm-messaging/mq-golang/issues/203

## How

By using [sync.Once](https://pkg.go.dev/sync#Once) instead of a `bool` to ensure the initialization block gets called only once.

## Testing

Running `go test -race ./...` after I added `TestGetAttrInfoConcurrentCalls` without the fix would yield output such as:
```
==================
WARNING: DATA RACE
Read at 0x0001058dcc8d by goroutine 21:
  github.com/ibm-messaging/mq-golang/v5/ibmmq.getAttrInfo()
      /Users/foo/bar/mq-golang/ibmmq/mqiattrs.go:144 +0x34
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls.func1()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:335 +0x4c

Previous write at 0x0001058dcc8d by goroutine 15:
  github.com/ibm-messaging/mq-golang/v5/ibmmq.getAttrInfo()
      /Users/foo/bar/mq-golang/ibmmq/mqiattrs.go:158 +0x1b8
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls.func1()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:335 +0x4c

Goroutine 21 (running) created at:
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:334 +0x74
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1648 +0x40

Goroutine 15 (finished) created at:
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:334 +0x74
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1648 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00009e360 by goroutine 18:
  runtime.mapaccess1_fast32()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/runtime/map_fast32.go:13 +0x1bc
  github.com/ibm-messaging/mq-golang/v5/ibmmq.getAttrInfo()
      /Users/foo/bar/mq-golang/ibmmq/mqiattrs.go:162 +0x254
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls.func1()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:335 +0x4c

Previous write at 0x00c00009e360 by goroutine 15:
  runtime.mapaccess2_fast32()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/runtime/map_fast32.go:53 +0x1cc
  github.com/ibm-messaging/mq-golang/v5/ibmmq.getAttrInfo()
      /Users/foo/bar/mq-golang/ibmmq/mqiattrs.go:156 +0x164
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls.func1()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:335 +0x4c

Goroutine 18 (running) created at:
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:334 +0x74
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1648 +0x40

Goroutine 15 (finished) created at:
  github.com/ibm-messaging/mq-golang/v5/ibmmq.TestGetAttrInfoConcurrentCalls()
      /Users/foo/bar/mq-golang/ibmmq/ibmmq_test.go:334 +0x74
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1595 +0x194
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.21.3/libexec/src/testing/testing.go:1648 +0x40
==================
--- FAIL: TestGetAttrInfoConcurrentCalls (0.01s)
    testing.go:1465: race detected during execution of test
```
Now it's `ok    github.com/ibm-messaging/mq-golang/v5/ibmmq 1.453s`.

The test does not check whether `getAttrInfo`'s overall behavior stayed the same, it only checks for data races!

## Issues

https://github.com/ibm-messaging/mq-golang/issues/203
