### PR TITLE
fix getMaxSCOLength to take into account MQSCO_VERSION_7

### DIFF
--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -180,7 +180,9 @@ size_t getMaxCDLength() {
 
 size_t getMaxSCOLength() {
   size_t l;
-#if defined(MQSCO_VERSION_6)
+#if defined(MQSCO_VERSION_7)
+	l = MQSCO_LENGTH_7;
+#elif defined(MQSCO_VERSION_6)
   l = MQSCO_LENGTH_6;
 #else
   l = MQSCO_LENGTH_5; // The minimum supported here

--- a/ibmmq/mqiMQCNO.go
+++ b/ibmmq/mqiMQCNO.go
@@ -181,7 +181,7 @@ size_t getMaxCDLength() {
 size_t getMaxSCOLength() {
   size_t l;
 #if defined(MQSCO_VERSION_7)
-	l = MQSCO_LENGTH_7;
+  l = MQSCO_LENGTH_7;
 #elif defined(MQSCO_VERSION_6)
   l = MQSCO_LENGTH_6;
 #else


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [ ] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-golang/DCO1.1.txt)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-golang/CHANGES.md)
- [ ] You have completed the PR template below:

## What

Updated `getMaxSCOLength` to take `MQSCO_VERSION_7` into account

## How

This is a bug: `freeHTTPSKeyStore` tries to free this data, but because the C SCO structure isn't big enough, it tries to free memory from outside the structure

## Testing

I did not test this.

## Issues

Links to the github issue(s) (if present) that this pull request is resolving.
