### PR TITLE
Harden ReadPCFParameter against malformed PCF length fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Newest updates are at the top of this file.
 
+## Unreleased
+- ibmmq - Harden ReadPCFParameter against malformed length fields (oversized/negative)
+  so parsing untrusted PCF does not panic (DoS of monitoring processes)
+
 ## Jun 16 2026 - v5.7.2
 - Update for MQ 10
 - mqmetric - Individual metrics can be included/excluded from reporting

--- a/ibmmq/mqiPCF.go
+++ b/ibmmq/mqiPCF.go
@@ -425,8 +425,14 @@ func ReadPCFParameter(buf []byte) (*PCFParameter, int) {
 	case C.MQCFT_INTEGER_LIST:
 		binary.Read(p, endian, &pcfParm.Parameter)
 		binary.Read(p, endian, &count)
+		// Bound the loop by the data actually present. A malformed count would
+		// otherwise iterate billions of times and grow the slice without limit;
+		// binary.Read fails once the buffer is exhausted, so stop rather than
+		// trusting count.
 		for i := 0; i < int(count); i++ {
-			binary.Read(p, endian, &i32)
+			if err := binary.Read(p, endian, &i32); err != nil {
+				break
+			}
 			pcfParm.Int64Value = append(pcfParm.Int64Value, int64(i32))
 		}
 
@@ -439,33 +445,51 @@ func ReadPCFParameter(buf []byte) (*PCFParameter, int) {
 	case C.MQCFT_INTEGER64_LIST:
 		binary.Read(p, endian, &pcfParm.Parameter)
 		binary.Read(p, endian, &count)
+		// Same count guard as MQCFT_INTEGER_LIST: stop when the buffer runs out
+		// instead of trusting a possibly-malformed count.
 		for i := 0; i < int(count); i++ {
-			binary.Read(p, endian, &i64)
+			if err := binary.Read(p, endian, &i64); err != nil {
+				break
+			}
 			pcfParm.Int64Value = append(pcfParm.Int64Value, i64)
 		}
 
 	case C.MQCFT_STRING:
-		offset := int32(C.MQCFST_STRUC_LENGTH_FIXED)
+		offset := int(C.MQCFST_STRUC_LENGTH_FIXED)
 		binary.Read(p, endian, &pcfParm.Parameter)
 		binary.Read(p, endian, &pcfParm.CodedCharSetId)
 		binary.Read(p, endian, &pcfParm.stringLength)
-		s := string(buf[offset : pcfParm.stringLength+offset])
-		s = trimToNull(s)
-		pcfParm.String = append(pcfParm.String, s)
-		p.Next(int(pcfParm.strucLength - offset))
+		if raw, ok := pcfSlice(buf, offset, pcfParm.stringLength); ok {
+			s := trimToNull(string(raw))
+			pcfParm.String = append(pcfParm.String, s)
+		}
+		pcfSkip(p, int(pcfParm.strucLength)-offset)
 
 	case C.MQCFT_STRING_LIST:
 		binary.Read(p, endian, &pcfParm.Parameter)
 		binary.Read(p, endian, &pcfParm.CodedCharSetId)
 		binary.Read(p, endian, &count)
 		binary.Read(p, endian, &pcfParm.stringLength)
-		for i := 0; i < int(count); i++ {
-			offset := C.MQCFSL_STRUC_LENGTH_FIXED + i*int(pcfParm.stringLength)
-			s := string(buf[offset : int(pcfParm.stringLength)+offset])
-			s = trimToNull(s)
-			pcfParm.String = append(pcfParm.String, s)
+		// Guard count as well as each element's length: a huge count would
+		// otherwise loop for a long time or overflow the offset arithmetic.
+		// stringLength must be strictly positive - a zero length never advances
+		// the offset, so a huge count would still spin appending empty strings.
+		if count > 0 && pcfParm.stringLength > 0 {
+			offset := int(C.MQCFSL_STRUC_LENGTH_FIXED)
+			for i := 0; i < int(count); i++ {
+				off64 := int64(offset) + int64(i)*int64(pcfParm.stringLength)
+				if off64 < 0 || off64 > int64(len(buf)) {
+					break
+				}
+				raw, ok := pcfSlice(buf, int(off64), pcfParm.stringLength)
+				if !ok {
+					break
+				}
+				s := trimToNull(string(raw))
+				pcfParm.String = append(pcfParm.String, s)
+			}
 		}
-		p.Next(int(pcfParm.strucLength - C.MQCFSL_STRUC_LENGTH_FIXED))
+		pcfSkip(p, int(pcfParm.strucLength)-int(C.MQCFSL_STRUC_LENGTH_FIXED))
 
 	case C.MQCFT_GROUP:
 		// This reads the entire group, including the group elements.
@@ -474,9 +498,20 @@ func ReadPCFParameter(buf []byte) (*PCFParameter, int) {
 		binary.Read(p, endian, &pcfParm.ParameterCount)
 		offset := 16 // Include the Type/StrucLength words in the already-read count
 		bytesRead := 0
+		// Reject absurd/negative ParameterCount so we do not allocate huge slices
+		// or loop forever on malformed input.
+		if pcfParm.ParameterCount < 0 || int(pcfParm.ParameterCount) > fullLen {
+			return pcfParm, offset
+		}
 		pcfParm.GroupList = make([]*PCFParameter, pcfParm.ParameterCount)
 		for i := 0; i < int(pcfParm.ParameterCount); i++ {
+			if offset >= fullLen {
+				break
+			}
 			pcfParm.GroupList[i], bytesRead = ReadPCFParameter(buf[offset:])
+			if bytesRead <= 0 {
+				break
+			}
 			offset += bytesRead
 		}
 		return pcfParm, offset
@@ -484,12 +519,14 @@ func ReadPCFParameter(buf []byte) (*PCFParameter, int) {
 	case C.MQCFT_BYTE_STRING:
 		// The byte string is converted to a hex string as that's how
 		// we expect to use it in reporting
-		offset := int32(C.MQCFBS_STRUC_LENGTH_FIXED)
+		offset := int(C.MQCFBS_STRUC_LENGTH_FIXED)
 		binary.Read(p, endian, &pcfParm.Parameter)
 		binary.Read(p, endian, &pcfParm.stringLength)
-		s := hex.EncodeToString(buf[offset : pcfParm.stringLength+offset])
-		pcfParm.String = append(pcfParm.String, s)
-		p.Next(int(pcfParm.strucLength - offset))
+		if raw, ok := pcfSlice(buf, offset, pcfParm.stringLength); ok {
+			s := hex.EncodeToString(raw)
+			pcfParm.String = append(pcfParm.String, s)
+		}
+		pcfSkip(p, int(pcfParm.strucLength)-offset)
 
 	case C.MQCFT_INTEGER_FILTER:
 		binary.Read(p, endian, &pcfParm.Filter.Parameter)
@@ -498,25 +535,28 @@ func ReadPCFParameter(buf []byte) (*PCFParameter, int) {
 		pcfParm.Filter.FilterValue = int64(i32)
 
 	case C.MQCFT_STRING_FILTER:
-		offset := int32(C.MQCFSF_STRUC_LENGTH_FIXED)
+		offset := int(C.MQCFSF_STRUC_LENGTH_FIXED)
 
 		binary.Read(p, endian, &pcfParm.Filter.Parameter)
 		binary.Read(p, endian, &pcfParm.Filter.Operator)
 		binary.Read(p, endian, &pcfParm.CodedCharSetId)
 		binary.Read(p, endian, &pcfParm.stringLength)
-		s := string(buf[offset : pcfParm.stringLength+offset])
-		s = trimToNull(s)
-		pcfParm.Filter.FilterValue = s
-		p.Next(int(pcfParm.strucLength - offset))
+		if raw, ok := pcfSlice(buf, offset, pcfParm.stringLength); ok {
+			s := trimToNull(string(raw))
+			pcfParm.Filter.FilterValue = s
+		}
+		pcfSkip(p, int(pcfParm.strucLength)-offset)
 
 	case C.MQCFT_BYTE_STRING_FILTER:
-		offset := int32(C.MQCFBF_STRUC_LENGTH_FIXED)
+		offset := int(C.MQCFBF_STRUC_LENGTH_FIXED)
 		binary.Read(p, endian, &pcfParm.Filter.Parameter)
 		binary.Read(p, endian, &pcfParm.Filter.Operator)
 		binary.Read(p, endian, &pcfParm.stringLength)
-		s := hex.EncodeToString(buf[offset : pcfParm.stringLength+offset])
-		pcfParm.Filter.FilterValue = s
-		p.Next(int(pcfParm.strucLength - offset))
+		if raw, ok := pcfSlice(buf, offset, pcfParm.stringLength); ok {
+			s := hex.EncodeToString(raw)
+			pcfParm.Filter.FilterValue = s
+		}
+		pcfSkip(p, int(pcfParm.strucLength)-offset)
 
 	default:
 		// This should not happen, but if it does then dump various pieces of
@@ -531,11 +571,38 @@ func ReadPCFParameter(buf []byte) (*PCFParameter, int) {
 		// After dumping the stack, we will try to carry on regardless.
 		// Skip the remains of this structure, assuming it really is
 		// PCF and we just don't know how to process the element type
-		p.Next(int(pcfParm.strucLength - 8))
+		pcfSkip(p, int(pcfParm.strucLength)-8)
 	}
 
 	bytesRead := fullLen - p.Len()
 	return pcfParm, bytesRead
+}
+
+// pcfSlice returns buf[offset:offset+length] when the range lies entirely
+// inside buf. length comes from the wire as int32 and must be non-negative.
+// Returns ok=false for negative length, overflow, or a range past the buffer
+// end — callers must not panic on malformed PCF.
+func pcfSlice(buf []byte, offset int, length int32) ([]byte, bool) {
+	if length < 0 || offset < 0 {
+		return nil, false
+	}
+	end := int64(offset) + int64(length)
+	if end < int64(offset) || end > int64(len(buf)) {
+		return nil, false
+	}
+	return buf[offset:int(end)], true
+}
+
+// pcfSkip advances p by n bytes, clamping to the remaining buffer and
+// ignoring negative skips (malformed StrucLength).
+func pcfSkip(p *bytes.Buffer, n int) {
+	if n <= 0 {
+		return
+	}
+	if n > p.Len() {
+		n = p.Len()
+	}
+	p.Next(n)
 }
 
 func roundTo4(u int32) int32 {

--- a/ibmmq/mqiPCF_bounds_test.go
+++ b/ibmmq/mqiPCF_bounds_test.go
@@ -1,0 +1,252 @@
+/*
+  Copyright (c) IBM Corporation 2026
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package ibmmq
+
+/*
+Regression tests for bounds checking in ReadPCFParameter.
+
+Malformed PCF elements previously used wire length fields directly in Go
+slice expressions (e.g. buf[offset:offset+stringLength]), which panics on
+oversized or negative lengths and can crash monitoring processes that parse
+untrusted reply/statistics messages.
+
+These tests construct minimal on-wire elements (no full MQCFH) and assert
+that ReadPCFParameter returns without panicking.
+*/
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// Element type constants from cmqcfc.h (avoid relying on C names in assertions).
+const (
+	testMQCFT_INTEGER_LIST       = 5
+	testMQCFT_STRING             = 4
+	testMQCFT_STRING_LIST        = 6
+	testMQCFT_BYTE_STRING        = 9
+	testMQCFT_STRING_FILTER      = 14
+	testMQCFT_BYTE_STRING_FILTER = 15
+	testMQCFT_INTEGER64_LIST     = 25
+)
+
+func testBuildStringParm(stringLength int32, payload string) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, endian, int32(testMQCFT_STRING))
+	body := []byte(payload)
+	// StrucLength = fixed (20) + rounded payload; use honest length of what we write
+	strucLen := int32(20 + len(body))
+	_ = binary.Write(buf, endian, strucLen)
+	_ = binary.Write(buf, endian, int32(1)) // Parameter
+	_ = binary.Write(buf, endian, int32(0)) // CCSID
+	_ = binary.Write(buf, endian, stringLength)
+	buf.Write(body)
+	return buf.Bytes()
+}
+
+func testBuildByteStringParm(stringLength int32, payload string) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, endian, int32(testMQCFT_BYTE_STRING))
+	body := []byte(payload)
+	strucLen := int32(16 + len(body))
+	_ = binary.Write(buf, endian, strucLen)
+	_ = binary.Write(buf, endian, int32(1)) // Parameter
+	_ = binary.Write(buf, endian, stringLength)
+	buf.Write(body)
+	return buf.Bytes()
+}
+
+func testBuildStringListParm(count, stringLength int32, one string) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, endian, int32(testMQCFT_STRING_LIST))
+	// fixed header 24 bytes then count*stringLength of data (we write one honest element)
+	body := []byte(one)
+	// pad body to stringLength if positive and small
+	if stringLength > 0 && int(stringLength) >= len(body) && stringLength < 1024 {
+		padded := make([]byte, int(stringLength))
+		copy(padded, body)
+		body = padded
+	}
+	strucLen := int32(24 + len(body))
+	_ = binary.Write(buf, endian, strucLen)
+	_ = binary.Write(buf, endian, int32(1)) // Parameter
+	_ = binary.Write(buf, endian, int32(0)) // CCSID
+	_ = binary.Write(buf, endian, count)
+	_ = binary.Write(buf, endian, stringLength)
+	buf.Write(body)
+	return buf.Bytes()
+}
+
+func testBuildStringFilterParm(stringLength int32, payload string) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, endian, int32(testMQCFT_STRING_FILTER))
+	body := []byte(payload)
+	strucLen := int32(24 + len(body))
+	_ = binary.Write(buf, endian, strucLen)
+	_ = binary.Write(buf, endian, int32(1)) // Filter Parameter
+	_ = binary.Write(buf, endian, int32(1)) // Operator
+	_ = binary.Write(buf, endian, int32(0)) // CCSID
+	_ = binary.Write(buf, endian, stringLength)
+	buf.Write(body)
+	return buf.Bytes()
+}
+
+func testBuildByteStringFilterParm(stringLength int32, payload string) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, endian, int32(testMQCFT_BYTE_STRING_FILTER))
+	body := []byte(payload)
+	strucLen := int32(20 + len(body))
+	_ = binary.Write(buf, endian, strucLen)
+	_ = binary.Write(buf, endian, int32(1)) // Filter Parameter
+	_ = binary.Write(buf, endian, int32(1)) // Operator
+	_ = binary.Write(buf, endian, stringLength)
+	buf.Write(body)
+	return buf.Bytes()
+}
+
+func testBuildIntegerListParm(count int32, values []int32) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, endian, int32(testMQCFT_INTEGER_LIST))
+	strucLen := int32(16 + 4*len(values)) // fixed header 16 + 4 bytes per value
+	_ = binary.Write(buf, endian, strucLen)
+	_ = binary.Write(buf, endian, int32(1)) // Parameter
+	_ = binary.Write(buf, endian, count)    // possibly-lying count
+	for _, v := range values {
+		_ = binary.Write(buf, endian, v)
+	}
+	return buf.Bytes()
+}
+
+func testBuildInteger64ListParm(count int32, values []int64) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, endian, int32(testMQCFT_INTEGER64_LIST))
+	strucLen := int32(16 + 8*len(values)) // fixed header 16 + 8 bytes per value
+	_ = binary.Write(buf, endian, strucLen)
+	_ = binary.Write(buf, endian, int32(1)) // Parameter
+	_ = binary.Write(buf, endian, count)    // possibly-lying count
+	for _, v := range values {
+		_ = binary.Write(buf, endian, v)
+	}
+	return buf.Bytes()
+}
+
+// mustNotPanic fails the test if ReadPCFParameter panics.
+func mustNotPanic(t *testing.T, name string, buf []byte) (parm *PCFParameter, n int) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s: ReadPCFParameter panicked: %v", name, r)
+		}
+	}()
+	return ReadPCFParameter(buf)
+}
+
+func TestReadPCFParameterValidString(t *testing.T) {
+	buf := testBuildStringParm(2, "AB")
+	parm, n := mustNotPanic(t, "valid-string", buf)
+	if n <= 0 {
+		t.Fatalf("expected positive bytesRead, got %d", n)
+	}
+	if len(parm.String) != 1 || parm.String[0] != "AB" {
+		t.Fatalf("unexpected string value: %+v", parm.String)
+	}
+}
+
+func TestReadPCFParameterValidByteString(t *testing.T) {
+	buf := testBuildByteStringParm(2, "AB")
+	parm, _ := mustNotPanic(t, "valid-bytestring", buf)
+	// hex of "AB"
+	if len(parm.String) != 1 || parm.String[0] != "4142" {
+		t.Fatalf("unexpected byte string hex: %+v", parm.String)
+	}
+}
+
+func TestReadPCFParameterMalformedLengthsNoPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{"string/oversized", testBuildStringParm(1<<20, "AB")},
+		{"string/maxint", testBuildStringParm(0x7FFFFFFF, "AB")},
+		{"string/negative", testBuildStringParm(-1, "AB")},
+		{"bytestring/oversized", testBuildByteStringParm(1<<20, "AB")},
+		{"bytestring/maxint", testBuildByteStringParm(0x7FFFFFFF, "AB")},
+		{"bytestring/negative", testBuildByteStringParm(-1, "AB")},
+		{"stringlist/oversized", testBuildStringListParm(1, 1<<20, "AB")},
+		{"stringlist/maxint", testBuildStringListParm(1, 0x7FFFFFFF, "AB")},
+		{"stringlist/negative-len", testBuildStringListParm(1, -1, "AB")},
+		{"stringfilter/maxint", testBuildStringFilterParm(0x7FFFFFFF, "AB")},
+		{"stringfilter/negative", testBuildStringFilterParm(-1, "AB")},
+		{"bytestringfilter/maxint", testBuildByteStringFilterParm(0x7FFFFFFF, "AB")},
+		{"bytestringfilter/negative", testBuildByteStringFilterParm(-1, "AB")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _ = mustNotPanic(t, tc.name, tc.buf)
+		})
+	}
+}
+
+// A malformed count must not drive the list loops past the data actually
+// present: the number of decoded values is bounded by the buffer, not by the
+// wire count. Previously these loops trusted count and would spin billions of
+// times, growing the slice until the process ran out of memory.
+func TestReadPCFParameterIntegerListHugeCountBounded(t *testing.T) {
+	// count claims 0x7FFFFFFF but only two int32 values follow.
+	buf := testBuildIntegerListParm(0x7FFFFFFF, []int32{10, 20})
+	parm, _ := mustNotPanic(t, "intlist/hugecount", buf)
+	if len(parm.Int64Value) != 2 {
+		t.Fatalf("expected loop bounded to 2 present values, got %d", len(parm.Int64Value))
+	}
+}
+
+func TestReadPCFParameterInteger64ListHugeCountBounded(t *testing.T) {
+	buf := testBuildInteger64ListParm(0x7FFFFFFF, []int64{10, 20})
+	parm, _ := mustNotPanic(t, "int64list/hugecount", buf)
+	if len(parm.Int64Value) != 2 {
+		t.Fatalf("expected loop bounded to 2 present values, got %d", len(parm.Int64Value))
+	}
+}
+
+// stringLength == 0 combined with a huge count previously spun forever
+// appending empty strings (the offset never advances). The guard now requires
+// a strictly positive length, so no strings are produced and the call returns.
+func TestReadPCFParameterStringListZeroLenHugeCount(t *testing.T) {
+	buf := testBuildStringListParm(0x7FFFFFFF, 0, "")
+	parm, _ := mustNotPanic(t, "stringlist/zerolen-hugecount", buf)
+	if len(parm.String) != 0 {
+		t.Fatalf("expected no strings for zero-length elements, got %d", len(parm.String))
+	}
+}
+
+func TestPCFSliceHelper(t *testing.T) {
+	buf := []byte{1, 2, 3, 4, 5}
+	if _, ok := pcfSlice(buf, 0, 5); !ok {
+		t.Fatal("expected full slice ok")
+	}
+	if _, ok := pcfSlice(buf, 1, 5); ok {
+		t.Fatal("expected overflow rejected")
+	}
+	if _, ok := pcfSlice(buf, 0, -1); ok {
+		t.Fatal("expected negative rejected")
+	}
+	if _, ok := pcfSlice(buf, 0, 0x7FFFFFFF); ok {
+		t.Fatal("expected huge length rejected")
+	}
+}


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-golang/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/ibm-messaging/mq-golang/blob/master/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

`ReadPCFParameter` (`ibmmq/mqiPCF.go`) decoded several PCF element types using
length/count fields taken directly from the message bytes, without validating
them first:

- `MQCFT_STRING`, `MQCFT_BYTE_STRING`, `MQCFT_STRING_FILTER` and
  `MQCFT_BYTE_STRING_FILTER` sliced the buffer with the on-wire `StringLength`
  (`buf[offset : offset+stringLength]`), which panics on an oversized or
  negative length.
- `MQCFT_STRING_LIST`, `MQCFT_INTEGER_LIST`, `MQCFT_INTEGER64_LIST` and
  `MQCFT_GROUP` looped on an on-wire count / parameter-count that could be
  arbitrarily large.

A crafted message (for example `StringLength = 0x7FFFFFFF`) produces
`panic: runtime error: slice bounds out of range`, and an oversized count leads
to unbounded looping/allocation. A long-running process that parses untrusted
PCF — e.g. a monitoring/metrics exporter reading reply or statistics messages —
can be crashed or driven to resource exhaustion, i.e. a denial of service of the
monitoring path. It is not a queue-manager crash and not remote code execution.

## How

- Added two small helpers:
  - `pcfSlice(buf, offset, length)` returns the sub-slice only when the range is
    non-negative and lies within the buffer (overflow-checked with int64
    arithmetic); otherwise it reports failure and the caller skips the value.
  - `pcfSkip(p, n)` advances the reader by `n`, clamped to the bytes remaining,
    and ignores negative skips (malformed `StrucLength`).
- Routed all five string / byte-string element types through
  `pcfSlice`/`pcfSkip`, so a malformed length is skipped rather than panicking.
- Bounded the list loops:
  - `MQCFT_GROUP` rejects a negative or absurdly large `ParameterCount` and stops
    when the offset reaches the buffer end or a nested element makes no progress.
  - `MQCFT_INTEGER_LIST` / `MQCFT_INTEGER64_LIST` stop when the buffer is
    exhausted instead of trusting the count.
  - `MQCFT_STRING_LIST` requires a strictly-positive element length so a huge
    count cannot spin without advancing.
- No behavioural change for well-formed PCF.

## Testing

Added `ibmmq/mqiPCF_bounds_test.go`:

- valid string / byte-string round-trips (unchanged behaviour),
- malformed-length cases (oversized, `0x7FFFFFFF`, negative) across all five
  string / byte-string element types, asserting no panic,
- huge-count cases for integer-list, integer64-list and zero-length string-list,
  asserting the decoded output is bounded by the buffer,
- a direct unit test of `pcfSlice`.

With the IBM MQ client installed:

```
go test ./ibmmq/ -run 'TestReadPCFParameter|TestPCFSlice' -v
```

All pass. For comparison, the same malformed inputs panic on current `master`
(`slice bounds out of range [:-2147483629]`) and are handled safely with this
change.

## Issues

None filed.
